### PR TITLE
Add .idea directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@
 /web/fonts
 /node_modules
 /bin/*
+/.idea
 .env
 npm-debug.log


### PR DESCRIPTION
In fact that all students are provided with PHPStorm software it would be reasonable to add .idea directory to .gitignore file as I notice constantly it appears in most NFQ Academy init commits just like here: https://github.com/nfqakademija/energy-shake

Even if it is not added because of learning purposes, I bet there will be other circumstances during project development to learn how to manage the ignored files and folders in git repo.