### PR TITLE
Fix for not working scripts/install-prod.sh

### DIFF
--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -16,9 +16,25 @@ fi
 if [ "$ARGS" != "" ]; then
     echo "Executing in PHP container: $ARGS"
     docker exec -it php.symfony bash -c "$ARGS"
+    
+    # Fix for known docker issue, when with "-it" parameter, command exits with status 129
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 129 ]; then
+		exit 0
+	else
+		exit $EXIT_CODE
+	fi  
 else
     echo "Dependencies can be installed via: composer install"
     echo "Many Symfony tools can be accessed via: bin/console"
     echo 'Type "exit" to get out of terminal'
     docker exec -it php.symfony bash
+    
+    # Fix for known docker issue, when with "-it" parameter, command exits with status 129
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -eq 129 ]; then
+		exit 0
+	else
+		exit $EXIT_CODE
+	fi  
 fi


### PR DESCRIPTION
For fresh applications, docker may exit with `129` code instead of `0`.

## Symptoms

![php-issue-symtms](https://user-images.githubusercontent.com/1453957/48375440-aaec5080-e6d0-11e8-8971-00125da97108.jpeg)
No `node` dependencies and `encore` executed

![docker-symfony-issue-build-not-found](https://user-images.githubusercontent.com/1453957/48375464-bf304d80-e6d0-11e8-8bd8-ce2360584b74.jpeg)
Errors on 127.0.0.1:8000

## Expected result

![docker-issue-expected-results](https://user-images.githubusercontent.com/1453957/48375497-d111f080-e6d0-11e8-8fe1-b84ccf6c2a05.jpeg)

![docker-expected-result](https://user-images.githubusercontent.com/1453957/48375556-0585ac80-e6d1-11e8-8ed2-a764e95b9e1e.jpeg)

## Details 

Issue found on: `Docker version 17.03.2-ce, build f5ec1e2` (linux).

## Related

https://github.com/docker/compose/issues/3379
