### PR TITLE
Fix script to simulate production environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ scripts/start.sh
 
 * Įsidiegiame PHP ir JavaScript bibliotekas:
 ```bash
-scripts/install-prod.sh
+install-first.sh
 ```
 
 * Pasižiūrime, ar veikia.
@@ -68,6 +68,11 @@ scripts/stop.sh
 * _Development_ režimas (detalesnė informacija apie klaidas, automatiškai generuojami JavaScript/CSS):
 ```bash
 scripts/install-dev.sh
+```
+
+* _Production_ režimas (imituoti, kaip daroma LIVE serveryje. Plačiau [.deploy/build.sh](.deploy/build.sh)):
+```bash
+scripts/install-prod.sh
 ```
 
 * Jei norite pridėti PHP biblioteką arba dirbti su Symfony karkasu per komandinę eilutę:

--- a/scripts/install-first.sh
+++ b/scripts/install-first.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
 
-
 # Make us independent from working directory
 pushd `dirname $0` > /dev/null
 SCRIPT_DIR=`pwd`
 popd > /dev/null
 
-# Check for common configuration error
-if [ `grep "APP_ENV=prod" "$SCRIPT_DIR/../.env" | wc -l` != "1" ]; then
-    echo >&2 "You need to configure APP_ENV=prod in .env";
-    echo >&2 "to switch to production configuration";
-    exit 1
-fi
-
 set -e
 
 # Installing dependencies
 echo "Preparing PHP dependencies..."
-APP_ENV=prod $SCRIPT_DIR/backend.sh composer install --no-dev
+APP_ENV=dev $SCRIPT_DIR/backend.sh composer install
 echo ""
 echo "Preparing JavaScript/CSS dependencies..."
 echo ""
@@ -25,6 +17,6 @@ $SCRIPT_DIR/frontend.sh yarn
 echo ""
 echo "Preparing JavaScript/CSS dependencies..."
 echo ""
-$SCRIPT_DIR/frontend.sh yarn run encore production
+$SCRIPT_DIR/frontend.sh yarn run encore dev
 
 echo "Open your browser at http://127.0.0.1:8000"


### PR DESCRIPTION
So there will not be strange `MakerBundle` not found issues.
We need to use `APP_ENV` consistently.

Using simple `yarn` (not `yarn --environment=production`),
because assets are intended to be build before deploying to LIVE server
and server should have only compiled assets (no need for Node.js).

Added install-first.sh, because we needed some command to
just install dependencies and see something working.
`install-prod.sh` could make too much errors/warnings for the daily usage.
`install-dev.sh` is useful for watching file changes for JavaScript/CSS changes.