### PR TITLE
Hotfix: Use less inodes

### DIFF
--- a/.deploy/build.sh
+++ b/.deploy/build.sh
@@ -7,11 +7,18 @@ set -e # Stop on error
 set -x # Show commands being executed
 
 # Downloading dependencies and building frontend
-composer install --no-dev --no-scripts --no-interaction --optimize-autoloader
+APP_ENV=prod composer install --no-dev --no-scripts --no-interaction --optimize-autoloader
 yarn
 yarn run encore production
 
 # <-- This is a good place to add custom commands for your project
 
 # Generating deployment artifact (one file with everything you need to be deployed on the server)
-tar czf project.tar.gz * --exclude="node_modules" --exclude=".git" --owner 0 --group 0 --anchored
+tar czf project.tar.gz --owner 0 --group 0 --anchored $( \
+    ls -a | tail -n +3 \
+    | grep -v "node_modules" \
+    | grep -v ".git" \
+    | grep -v ".deploy" \
+    | grep -v ".docker" \
+    | grep -v ".idea" \
+)

--- a/.deploy/deploy_playbook.yaml
+++ b/.deploy/deploy_playbook.yaml
@@ -69,3 +69,4 @@
             path: "{{ deployment.deploy_path }}"
             release: "{{ deploy_helper.new_release }}"
             state: finalize
+            keep_releases: 2


### PR DESCRIPTION
WEB server was using all of `inode` because there were too many files created in WEB server.

Main problems were:
* Different behavior of `tar` `--exclude`, that was transferring all `node_modules`
* Many old releases with `vendor` directory

