### PR TITLE
Ignore PHPStorm settings file by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,14 @@
 /.docker/*
 ###< Infrastructure ###
 
+###> Local development environment settings files ###
+npm-debug.log
+.DS_Store
+Thumbs.db
+.idea/
+*~
+###< Infrastructure ###
+
 ###> squizlabs/php_codesniffer ###
 /.phpcs-cache
 /phpcs.xml


### PR DESCRIPTION
So there will be less accidental .idea folder pushes

Preferred way is to configure global git ignore rules

Example taken from https://gist.github.com/subfuzion/db7f57fff2fb6998a16c