### PR TITLE
Security update

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3595,9 +3595,9 @@ isstream@~0.1.2:
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
 jquery@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
jquery: ^3.4.0: [CVE-2019-11358](https://nvd.nist.gov/vuln/detail/CVE-2019-11358), [CVE-2019-11358](https://nvd.nist.gov/vuln/detail/CVE-2019-11358)
tar: >=4.4.2: [CVE-2018-20834](https://nvd.nist.gov/vuln/detail/CVE-2018-20834)

Issues caught by GitHub alerts:
![image](https://user-images.githubusercontent.com/1453957/57210767-84a3cf80-6fe6-11e9-8d0a-12fe2de0899a.png)
