### PR TITLE
Documentation regarding PSR2 vs PSR12 standard

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <rule ref="PSR12"/>
+    <rule ref="PSR2"/> <!-- Despite PSR2 is depracted in favor of PSR12: Symfony had too much code to rewrite, so is still based on PSR2 -->
 
     <file>src</file> <!-- Your code is stored here -->
     <file>public</file> <!-- Some of your code may be stored here -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
     <arg name="colors"/>
     <arg name="extensions" value="php"/>
 
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <file>src</file> <!-- Your code is stored here -->
     <file>public</file> <!-- Some of your code may be stored here -->


### PR DESCRIPTION
Symfony has its own coding standard, that is based on PSR-2.
Despite the fact, that PSR-2 is deprecated.

Documentation:
 * https://www.php-fig.org/psr/psr-2/
 * https://github.com/symfony/symfony/issues/33324
 * https://symfony.com/doc/current/contributing/code/standards.html
 * https://blog.jetbrains.com/phpstorm/2019/10/phpstorm-2019-3-eap-5/