### PR TITLE
Compatibility for GitHub actions

### DIFF
--- a/scripts/backend.sh
+++ b/scripts/backend.sh
@@ -12,10 +12,14 @@ if [ `docker ps | grep php.symfony | wc -l` != "1" ]; then
     exit 1
 fi
 
+if [ -t 0 ]; then
+    TTY="-it" # Current shell/terminal have stdin file descriptor. So we can use interactive (-it) mode
+fi
+
 # Entering into PHP container (simulating SSH/terminal)
 if [ "$ARGS" != "" ]; then
     echo "Executing in PHP container: $ARGS"
-    docker exec -it php.symfony bash -c "$ARGS"
+    docker exec ${TTY} php.symfony $ARGS
     
     # Fix for known docker issue, when with "-it" parameter, command exits with status 129
     EXIT_CODE=$?
@@ -28,7 +32,7 @@ else
     echo "Dependencies can be installed via: composer install"
     echo "Many Symfony tools can be accessed via: bin/console"
     echo 'Type "exit" to get out of terminal'
-    docker exec -it php.symfony bash
+    docker exec ${TTY} php.symfony bash
     
     # Fix for known docker issue, when with "-it" parameter, command exits with status 129
     EXIT_CODE=$?

--- a/scripts/frontend.sh
+++ b/scripts/frontend.sh
@@ -15,7 +15,7 @@ docker-compose --version > /dev/null 2>&1 || { echo >&2 "Docker-compose not foun
 # Entering into Node.js container (simulating SSH/terminal)
 if [ "$ARGS" != "" ]; then
     echo "Executing in Node.js (frontend) container: $ARGS"
-    docker-compose -f "$SCRIPT_DIR/docker-compose-tools.yml" run frontend.symfony bash -c "$ARGS"
+    docker-compose -f "$SCRIPT_DIR/docker-compose-tools.yml" run frontend.symfony $ARGS
 else
     echo "JavaScript/CSS dependencies can be installed via: yarn"
     echo "Assets compiling for production: yarn run encore production"

--- a/scripts/install-prod.sh
+++ b/scripts/install-prod.sh
@@ -29,7 +29,7 @@ fi
 
 # Installing dependencies
 echo "Preparing PHP dependencies..."
-APP_ENV=prod $SCRIPT_DIR/backend.sh composer install --no-dev
+APP_ENV=prod $SCRIPT_DIR/backend.sh "composer install --no-dev"
 echo ""
 echo "Preparing JavaScript/CSS dependencies..."
 echo ""
@@ -37,6 +37,6 @@ $SCRIPT_DIR/frontend.sh yarn
 echo ""
 echo "Preparing JavaScript/CSS dependencies..."
 echo ""
-$SCRIPT_DIR/frontend.sh yarn run encore production
+$SCRIPT_DIR/frontend.sh "yarn run encore production"
 
 echo "Open your browser at http://127.0.0.1:8000"

--- a/scripts/mysql.sh
+++ b/scripts/mysql.sh
@@ -20,4 +20,9 @@ echo "Port: $PORT"
 echo ""
 echo 'Type "exit" to get out of MySql terminal'
 echo ""
-docker exec -it mysql.symfony mysql -uroot -h127.0.0.1 --password=p9iijKcfgENjBWDYgSH7
+
+if [ -t 0 ]; then
+    TTY="-it" # Current shell/terminal have stdin file descriptor. So we can use interactive (-it) mode
+fi
+
+docker exec ${TTY} mysql.symfony mysql -uroot -h127.0.0.1 --password=p9iijKcfgENjBWDYgSH7


### PR DESCRIPTION
GitHub Actions (workflow/CI) does not have `stdin`, so running docker fails.
Added check for available sdin (TTY).

Known issues:
 * Docker in docker use different users, so it is needed to change permissions for root and public folders.

Related documentation:
 * https://help.github.com/en/actions/automating-your-workflow-with-github-actions
 * https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-output-parameter-set-output
 * https://help.github.com/en/actions/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions#job-status-check-functions