### PR TITLE
Fix documentation: GitHub actions instead of TravisCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ visais reikalingais failais ir įrankiais darbui:
 - Paprastas pavyzdys (Controller, Template, CSS)
 - Įdiegtas bootstrap
 - Asset'ų buildinimas (encore, yarn, sass)
-- Travis CI template
-
+- GitHub actions (CI) pavyzdys
 
 # Paleidimo instrukcija
 


### PR DESCRIPTION
We migrated from [Travis](https://travis-ci.org/) to [GitHub actions](https://github.com/features/actions).
GitHub actions are fully integrated with GitHub (no need for special permissions/configuration per student/mentor).

Related:
 * https://github.com/nfqakademija/kickstart/pull/60
 * https://github.com/nfqakademija/kickstart/pull/65